### PR TITLE
iOS fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ default:
 android:
 	cmake/cmakemake --platform=Android
 
-ios: bin/ios-deploy
+ios:
 	cmake/cmakemake --platform=iOS
 
 xcode:
@@ -23,10 +23,3 @@ clean:
 
 install:
 	make install --dir=build/Release
-
-bin/ios-deploy: | bin
-	xcodebuild -project 3rdparty/ios-deploy/ios-deploy.xcodeproj
-	cp -f 3rdparty/ios-deploy/build/Release/ios-deploy bin
-
-bin:
-	mkdir bin

--- a/cmake/toolchain/iOS.cmake
+++ b/cmake/toolchain/iOS.cmake
@@ -156,7 +156,7 @@ set (CMAKE_OSX_SYSROOT ${CMAKE_IOS_SDK_ROOT} CACHE PATH "Sysroot used for iOS su
 
 # set the architecture for iOS
 if (${IOS_PLATFORM} STREQUAL "OS")
-    set (IOS_ARCH armv7 armv7s arm64)
+    set (IOS_ARCH armv7 armv7s arm64 arm64e)
 elseif (${IOS_PLATFORM} STREQUAL "SIMULATOR")
     set (IOS_ARCH i386)
 elseif (${IOS_PLATFORM} STREQUAL "SIMULATOR64")


### PR DESCRIPTION
- Drop `ios-deploy` (build error and not used anymore)
- Upgrade SDL2 (fixes build error)
- Add `arm64e` architecture (fuse-open/uno#253)